### PR TITLE
unoserver2 to handle multiple listener nodes active simultaneously.

### DIFF
--- a/BaseStation/unoserver2/unoserver2.ino
+++ b/BaseStation/unoserver2/unoserver2.ino
@@ -252,13 +252,13 @@ static void initOOKRadio()
   digitalWrite(outputRFTxPin, LOW);
 }
 //####################################################################
-static byte inList(const int& val,const byte list[])
-{
-  byte i;
-  for (i=0; i<N_LISTENERS; i++)
-    if (list[i] == val) break;
-  return i; 
-}
+/* static byte inList(const int& val,const byte list[]) */
+/* { */
+/*   byte i; */
+/*   for (i=0; i<N_LISTENERS; i++) */
+/*     if (list[i] == val) break; */
+/*   return i;  */
+/* } */
 //####################################################################
 static short int getByte(short int target, short int which)
 {
@@ -274,16 +274,14 @@ static short int setByte(short int word, short int nibble, short int whichByte)
 //---------------------------------------------
 // Send payload data via RF
 //---------------------------------------------
-static void rfwrite(const int& nodeid)
+static void rfwrite(const int& nodendx)
 {
-  //if (TX_payload.supplyV != NOTHING_TO_SEND)
   {
-    //Serial.println("{\rf_fail:1, \"source\":\"rfwrite\"}\0");
     rf12_sleep(-1);     //wake up RF module
     while (!rf12_canSend()) rf12_recvDone();
-    rf12_sendStart(0, &TX_payload[nodeid], sizeof TX_payload[nodeid]); 
+    rf12_sendStart(0, &TX_payload[nodendx], sizeof TX_payload[nodendx]);
     rf12_sendWait(1);    //wait for RF to finish sending while in IDLE (1) mode (standby is 2 -- does not work with JeeLib 2018)
-    rf12_sendStart(0, &TX_payload[nodeid], sizeof TX_payload[nodeid]); 
+    rf12_sendStart(0, &TX_payload[nodendx], sizeof TX_payload[nodendx]);
     rf12_sendWait(1);    //wait for RF to finish sending while in IDLE (1) mode (standby is 2 -- does not work with JeeLib 2018)
     //       rf12_sleep(0);    //put RF module to sleep
   }

--- a/BaseStation/unoserver2/unoserver2.ino
+++ b/BaseStation/unoserver2/unoserver2.ino
@@ -213,7 +213,7 @@ void loop()
 			     +(",\"param1\":") + ("\"") + String(GET_TIMEOUT(TX_payload[n]))+" " +String(TX_counter[n])+("\" }\0"));
 	    }
 	  else
-	    Serial.println("{\"rf_fail\":1,\"source\":\"ERROR RFM_SEND\",\"node\":"+String(n));
+	    Serial.println("{\"rf_fail\":1,\"source\":\"ERROR RFM_SEND\",\"node\":"+String(v)+(" }\0"));
 	}
       // Read a value from sensorTMP36PIN and return the value as
       // temperature in degC
@@ -332,7 +332,8 @@ static bool processACK(const int rx_nodeID, const int rx_rx, const int rx_supply
   // sent in the absence of any RFM_SEND command received on the
   // serial port).
   //
-  for(n=0;n<N_LISTENERS;n++) if (rx_nodeID == listenerNodeIDList[n]) break;
+  n = inList(rx_nodeID, listenerNodeIDList);
+  //  for(n=0;n<N_LISTENERS;n++) if (rx_nodeID == listenerNodeIDList[n]) break;
   
   if ((n < N_LISTENERS)  && (rx_nodeID == GET_NODEID(TX_payload[n])) && (rx_rx == TX_payload[n].rx1))
     {

--- a/BaseStation/unoserver2/unoserver2.ino
+++ b/BaseStation/unoserver2/unoserver2.ino
@@ -89,7 +89,7 @@ static byte TX_counter[N_LISTENERS]={N_TRIALS+1,N_TRIALS+1};
 #define GET_PORT(p)     (getByte(p.rx1,1))
 #define GET_TIMEOUT(p)  (getByte(p.rx1,0))
 
-#define INIT_TXPKT(n)  {TX_payload[n].supplyV=0;SET_CMD(TX_payload[n],NOOP);SET_PORT(TX_payload[n],0);SET_TIMEOUT(TX_payload[n],0);}//Set cmd to NOOP
+#define INIT_TXPKT(n)  {TX_payload[n].supplyV=0;SET_NODEID(TX_payload[n],listenerNodeIDList[n]);SET_CMD(TX_payload[n],NOOP);SET_PORT(TX_payload[n],0);SET_TIMEOUT(TX_payload[n],0);}//Set cmd to NOOP
 #define DISABLE_TXPKT(n) (TX_counter[n]=N_TRIALS+1) // Set the count to > allowed no. of trials
 #define ENABLE_TXPKT(n)  (TX_counter[n]=0) // Set the counter to zero, indicating that the TX pkt. needs is ready to be sent
 #define TXPKT_ENABLED(n)  (TX_counter[n] < N_TRIALS) // Check if TX counter is less than max. allowed trials

--- a/BaseStation/unoserver2/unoserver2.ino
+++ b/BaseStation/unoserver2/unoserver2.ino
@@ -209,8 +209,8 @@ void loop()
 	      // listening on the serial port need not process it further.
 	      Serial.println("{\"rf_fail\":1,\"source\":\"Got RFM_SEND\",\"cmd\":"+String(GET_CMD(TX_payload[n]))
 			     +(",\"node\":") + String(GET_NODEID(TX_payload[n]))+s
-			     +(",\"port\":") + String(GET_PORT(TX_payload[n]))+s
-			     +(",\"TIMEOUT\":") + ("\"") + String(GET_TIMEOUT(TX_payload[n]))+" " +String(TX_counter[n])+("\" }\0"));
+			     +(",\"param0\":") + String(GET_PORT(TX_payload[n]))+s
+			     +(",\"param1\":") + ("\"") + String(GET_TIMEOUT(TX_payload[n]))+" " +String(TX_counter[n])+("\" }\0"));
 	    }
 	  else
 	    Serial.println("{\"rf_fail\":1,\"source\":\"ERROR RFM_SEND\",\"node\":"+String(n));
@@ -311,8 +311,8 @@ static void printJSON(const byte* counter,const int& nodeid)
   Serial.println("{\"rf_fail\":1,\"source\":\"Sending RFM_SEND\""
 		 ",\"cmd\":"+String(GET_CMD(TX_payload[nodeid]))
 		 +(",\"node\":") + String(GET_NODEID(TX_payload[nodeid]))+(" ")
-		 +(",\"port\":") + String(GET_PORT(TX_payload[nodeid]))+(" ")
-		 +(",\"TIMEOUT\":") + ("\"") + String(GET_TIMEOUT(TX_payload[nodeid]))+(" ")
+		 +(",\"param0\":") + String(GET_PORT(TX_payload[nodeid]))+(" ")
+		 +(",\"param1\":") + ("\"") + String(GET_TIMEOUT(TX_payload[nodeid]))+(" ")
 		 +String(counter[nodeid])+("\" }\0")); 
 }
 //####################################################################
@@ -338,8 +338,8 @@ static bool processACK(const int rx_nodeID, const int rx_rx, const int rx_supply
     {
       Serial.println("{\"rf_fail\":1,\"source\":\"ACKpkt:\",\"cmd\":"+String(GET_CMD(TX_payload[n]))
 		     +(",\"node\":") + String(GET_NODEID(TX_payload[n]))
-		     +(",\"t2\": ")+String(rx_rx)
-		     +(",\"t3\": ")+String(rx_nodeID)+(" }\0")); 
+		     +(",\"p0\": ")+String(getByte(rx_rx,1))
+		     +(",\"p1\": ")+String(rx_nodeID)+(" }\0")); 
       SET_CMD(TX_payload[n],NOOP);
       DISABLE_TXPKT(n);
       return true;

--- a/Nodes/TinyL9110S/RFM69_RxTx/RemoteCmd.h
+++ b/Nodes/TinyL9110S/RFM69_RxTx/RemoteCmd.h
@@ -18,25 +18,25 @@
 // sending it (the server UNO ID).  The NODE value (arg2 below) is the
 // ID of the target receiver node.
 //
-// ASCII          Arg1    Arg2     Arg3                  Arg4
-//               Nibble1 Nibble0 Nibble1               Nibble0
-// RFM_SEND         CMD    NODE    P1                      P0
+// ASCII            Arg1     Arg2      Arg3               Arg4
+//                Nibble1  Nibble0   Nibble1            Nibble0
+// RFM_SEND        NODE      CMD       P1                 P0
 //--------------------------------------------------------------------------------
-// VALVE CLOSE       0      N     PORT           TIMEOUT in minutes (default 30min)
+// VALVE CLOSE       N        0       PORT          TIMEOUT in minutes (default 30min)
 //
-// VALVE OPEN        1      N     PORT           TIMEOUT in minutes (default 30min)
+// VALVE OPEN        N        1       PORT          TIMEOUT in minutes (default 30min)
 //
-// VALVE SHUT        2      N     PORT           N/A
+// VALVE SHUT        N        2       PORT          N/A
 //
-// Set RX TO         3      N     N/A            TIMEOUT in  sec. (default 3sec)
+// Set RX TO         N        3        N/A          TIMEOUT in  sec. (default 3sec)
 //
-// Set TX interval   4      N     TO in sec.     Multiplier (default 1)
-//                                (default 60s)
+// Set TX interval   N        4      TO in sec.     Multiplier (default 1)
+//                                   (default 60s)
 //
-// Set valve pulse   5      N     Multiplier     Pulse width in milli sec.
-// width                                         (default 10ms)
+// Set valve pulse   N        5     Multiplier     Pulse width in milli sec.
+// width                                           (default 10ms)
 //
-// NOOP             255     N     N/A            N/A
+// NOOP              N       255       N/A         N/A
 //
 //
 // Cmd-0,1 (CLOSE,OPEN) raises the appropriate DIO pins to LOW/HIGH


### PR DESCRIPTION
A TX_payload, TX_counter and lastRFSend is maintained per registered listener node.  This allows communication with multiple listener nodes active simultaneously (e.g. asynchronously sending different commands to the various listeners).

The RFM_SEND command structure also changes.  It now is:
    RFM_SEND NODEID CMD PARAM0 PARAM1
i.e. the location NODEID and CMD in the argument list has flipped (earlier the command structure was "RFM_SEND CMD NODEID PARAM0 PARAM1").