### PR TITLE
Changes to reduce the sleep-mode current, now at 15-20uAmp

### DIFF
--- a/Nodes/TinyL9110S/RFM69_RxTx/RFM69_RxTx.ino
+++ b/Nodes/TinyL9110S/RFM69_RxTx/RFM69_RxTx.ino
@@ -133,14 +133,12 @@ void loop()
   digitalWrite(tempPower, HIGH); // turn TMP36 sensor on
   delay(10); // Allow 10ms for the sensor to be ready
 
-
   analogRead(tempPin); // throw away the first reading
   //payLoad_RxTx.temp=0.0;
   tempReading=0;
   for(byte i = 0; i < 10 ; i++) // take 10 more readings
     //payLoad_RxTx.temp += analogRead(tempPin); // accumulate readings
     tempReading += analogRead(tempPin); // accumulate readings
-    
 
   digitalWrite(tempPower, LOW); // turn TMP36 sensor off
   payLoad_RxTx.temp = int((((double(tempReading/10.0)*0.942382812) - 500)/10)*100);
@@ -149,8 +147,6 @@ void loop()
   
   rfwrite(1); // Send data via RF
   delay(10); // Without this delay, the second packet is never issued.  Why? 10ms does not work.  100ms does.  Is 10<d<100 possible?
-  
-  cmd=-1;
   
   lastRF=millis();
   rf12_sleep(RFM_WAKEUP);

--- a/Nodes/TinyL9110S/RFM69_RxTx/RFM69_RxTx.ino
+++ b/Nodes/TinyL9110S/RFM69_RxTx/RFM69_RxTx.ino
@@ -21,9 +21,12 @@
 #define RF69_COMPAT 1
 #pragma message("Compiling in RF69_COMPAT mode")
 #include <JeeLib.h> // https://github.com/jcw/jeelib
-#include <avr/power.h>
+//#include <avr/power.h>
 #include "RemoteCmd.h" // List of remote commands
 ISR(WDT_vect) { Sleepy::watchdogEvent(); } // interrupt handler for JeeLabs Sleepy power saving
+// Utility macros
+#define adc_disable() (ADCSRA &= ~(1<<ADEN)) // disable ADC (before power-off)
+#define adc_enable() (ADCSRA |= (1<<ADEN)) // re-enable ADC
 
 #define SERVER_NODE_ID 5
 #define MY_NODE_ID     16                     // RF12 node ID in the range 1-30
@@ -124,7 +127,8 @@ void setup()
 //#################################################################
 void loop()
 {
-  power_adc_enable();
+  //power_adc_enable();
+  adc_enable();
   // Turn-on the temperature sensor, read it and send the data via RF
   //----------------------------------------------------------------------------------------
 
@@ -132,6 +136,7 @@ void loop()
     {controlSolenoid(CLOSE);TimeOfLastValveCmd=0;}
   digitalWrite(tempPower, HIGH); // turn TMP36 sensor on
   delay(10); // Allow 10ms for the sensor to be ready
+
 
   analogRead(tempPin); // throw away the first reading
   //payLoad_RxTx.temp=0.0;
@@ -184,7 +189,8 @@ void loop()
     }
 
   rf12_sleep(RFM_SLEEP_FOREVER);    //put RF module to sleep
-  power_adc_disable();//Claim is that with this, the current consumption is down to 0.2uA from 230uA (!)
+  //power_adc_disable();//Claim is that with this, the current consumption is down to 0.2uA from 230uA (!)
+  adc_disable();//Claim is that with this, the current consumption is down to 0.2uA from 230uA (!)
   for(byte i=0;i<SYS_SHUTDOWN_INTERVAL_MULTIPLIER;i++)
     Sleepy::loseSomeTime(SYS_SHUTDOWN_INTERVAL); //JeeLabs power save function: enter low power mode for 60 seconds (valid range 16-65000 ms)
 }

--- a/Nodes/TinyL9110S/RFM69_RxTx/RFM69_RxTx.ino
+++ b/Nodes/TinyL9110S/RFM69_RxTx/RFM69_RxTx.ino
@@ -221,23 +221,25 @@ static void controlSolenoid(const int cmd)
     {
       digitalWrite(SOLENOID_CTL0, HIGH);
       digitalWrite(SOLENOID_CTL1, LOW);
-      for(byte i=0;i<PULSE_WIDTH_MULTIPLIER;i++) delay(VALVE_PULSE_WIDTH);
+      //for(byte i=0;i<PULSE_WIDTH_MULTIPLIER;i++) delay(VALVE_PULSE_WIDTH);
       TimeOfLastValveCmd=millis(); // Record the time when OPEN command is issued.
     }
   else if (cmd==CLOSE)
     {
       digitalWrite(SOLENOID_CTL0, LOW);
       digitalWrite(SOLENOID_CTL1, HIGH);
-      for(byte i=0;i<PULSE_WIDTH_MULTIPLIER;i++) delay(VALVE_PULSE_WIDTH);
-      TimeOfLastValveCmd=0; // Record that the valve is off now
+      //for(byte i=0;i<PULSE_WIDTH_MULTIPLIER;i++) delay(VALVE_PULSE_WIDTH);
+      //TimeOfLastValveCmd=0; // Record that the valve is off now
     }
-  //  else //Comment this line, and uncomment the delays in above blocks
-       //to ensure that OPEN and CLOSE are always followed by a delay
-       //and SHUT
+  //Ensure that OPEN and CLOSE are always followed by a delay to
+  //produce a finite pulse and then the SHUT command to set the CTL
+  //pins LOW
+  for(byte i=0;i<PULSE_WIDTH_MULTIPLIER;i++) delay(VALVE_PULSE_WIDTH);
+
     {
       digitalWrite(SOLENOID_CTL0, LOW);
       digitalWrite(SOLENOID_CTL1, LOW);
-      TimeOfLastValveCmd=0; // Record that the valve is off now
+      //TimeOfLastValveCmd=0; // Record that the valve is off now
     }
 }
 

--- a/Nodes/TinyL9110S/RFM69_RxTx/RFM69_RxTx.ino
+++ b/Nodes/TinyL9110S/RFM69_RxTx/RFM69_RxTx.ino
@@ -44,7 +44,7 @@ int RFM69_READ_TIMEOUT = 3000, // 3 sec
 #define RCV_TIMEDOUT      10
 #define RCV_GOT_SOME_PKT  20
 #define RCV_GOT_VALID_PKT 30
-#define MAX_RX_ATTEMPTS 10000
+#define MAX_RX_ATTEMPTS 50000  // Keep it <= 65535
 
 // Macros to extrat NodeID, Port No., Command and Timeout values
 // packed in the int-elements of the PayLoad struct.


### PR DESCRIPTION
Three small but significant changes in RFM69_RxTx which should significantly increase battery life on remote nodes:

1. RFM69_RxTx did not set the RFM to sleep for the cycle it failed to get an ACK packet from the central node.  The remote node would keep the radio in Rx mode for up to 60sec leading to substantial drainage of the battery.  This is now fixed.

2. The Rx loop now has a explicit counter (in addition to a timer) so that the loop has an assured exit, after which the system is put to deep-sleep till the next wake-up cycle.

3. Earlier I had switched to using power_adc_disable()/enable() functions to put ATT84 in deep-sleep.  For reasons I don't understand, this leaves the MCU drawing 200uAmp in this state.  Using the adc_disable()/enable() macros now in the code, the consumption is down to less 20uAmp.  

These three changes have been tested and have reduced the battery drain to less than a millivolt over 3 weeks and current drawn during the 60sec-long sleep is <20uAmp.  The current consumption of the RFM69CW in sleep mode was measured to be ~3uAmp. This code is read for use on the sprinkler controller, which itself now draws <0.1uAmp in sleep state.  

Changes in DRV8838Txt are partly cosmetic and partly tests to see if the MCU sleep-mode current can be reduced below 20uAmp.   